### PR TITLE
Added endpoint for verifying email domains on registration

### DIFF
--- a/lambdas/auth.js
+++ b/lambdas/auth.js
@@ -1,0 +1,48 @@
+"use strict";
+
+const AWS = require("aws-sdk"); // eslint-disable-line import/no-extraneous-dependencies
+
+const dynamoDb = new AWS.DynamoDB.DocumentClient();
+
+module.exports.auth = (event, context, callback) => {
+  const data = JSON.parse(event.body);
+
+  let email = data.email;
+  let domain = email.split("@")[1];
+
+  const params = {
+    TableName: "Aliases",
+    Key: {
+      alias: domain
+    }
+  };
+  dynamoDb.get(params, (error, result) => {
+    if (error) {
+      console.error(error);
+      callback(null, {
+        statusCode: error.statusCode || 501,
+        headers: { "Content-Type": "text/plain" },
+        body: JSON.stringify({ verified: false, error })
+      });
+      return;
+    }
+    let response;
+    if (result.Item) {
+      response = {
+        statusCode: 200,
+        body: JSON.stringify({ verified: true })
+      };
+    } else {
+      response = {
+        statusCode: 401,
+        body: JSON.stringify({
+          verified: false,
+          error:
+            "Please register using an email address managed under your school's domain"
+        })
+      };
+    }
+
+    callback(null, response);
+  });
+};

--- a/serverless.yml
+++ b/serverless.yml
@@ -42,3 +42,10 @@ functions:
           path: graphql
           method: post
           cors: true
+  verify-domain:
+    handler: dist/auth.auth
+    events:
+      - http:
+          path: verify
+          method: post
+          cors: true


### PR DESCRIPTION
Added endpoint that checks the dynamodb "Aliases" table to make sure that the email address ends in a valid, certified email.  Will return a 200 status code and a variable called "verified" to true.  If it is not found in the table it will return a 401 status code along with a variable called "verified" set to false.  It will also have another variable called "error" that will return a string describing what is wrong with the user's email they provided.