### PR TITLE
id to offer_id in test case

### DIFF
--- a/src/graphql/resolvers/getOfferResolver.test.js
+++ b/src/graphql/resolvers/getOfferResolver.test.js
@@ -19,7 +19,7 @@ describe("Resolvers", () => {
           })
         },
         args: {
-          id: "54321"
+          offer_id: "54321"
         },
         expectedDBCall: {
           TableName: "Offer",
@@ -45,7 +45,7 @@ describe("Resolvers", () => {
           })
         },
         args: {
-          id: "1423"
+          offer_id: "1423"
         },
         expectedDBCall: {
           TableName: "Offer",


### PR DESCRIPTION
A test was failing because the id on the offer table wasn't labeled as offer_id.