### PR TITLE
remove empty strings for offer upload

### DIFF
--- a/src/graphql/resolvers/postOfferResolver.js
+++ b/src/graphql/resolvers/postOfferResolver.js
@@ -72,7 +72,7 @@ const PostOfferResolver = async (db, args) => {
     delete args.offer.location;
 
     let uploadable = {
-      ...args.offer,
+      ...removeEmptyStrings(args.offer),
       location_id,
       offer_id: uuidv4(),
       company_name: company.name,
@@ -86,7 +86,7 @@ const PostOfferResolver = async (db, args) => {
 
     await db.put(postOfferParams).promise();
     return {
-      ...uploadable,
+      ...removeEmptyStrings(uploadable),
       offer_id: uploadable.offer_id
     };
   } catch (err) {


### PR DESCRIPTION
Allows offers to be uploaded even when a string is empty.

Here's a test that now works:
```
mutation {
  offer(offer: {
    company_name: "test"
    student_id:"5"
    position_type:"test"
    position_title:"test"
    benefits_description:""
    location:{
      city:"Provo"
      state:"UT"
      country:"USA"
    }
  } ) {
    company_name
    offer_id
  }
}

```