### PR TITLE
Jh/create type connections

### DIFF
--- a/src/graphql/resolvers/getCompaniesResolver.js
+++ b/src/graphql/resolvers/getCompaniesResolver.js
@@ -1,11 +1,11 @@
 import { TABLES } from "../environment";
-import { GetMany, GetFiltered } from "./resolverHelper";
+import { dbScan } from "./resolverHelper";
 
 /*
- * Returns a list of companies
+ * Returns a filtered list of companies
  */
 const GetCompaniesResolver = async (db, args) => {
-  let results = await GetFiltered(db, TABLES.Company, args.filters);
+  let results = await dbScan(db, TABLES.Company, args.filters);
   return { edges: results };
 };
 

--- a/src/graphql/resolvers/getCompaniesResolver.js
+++ b/src/graphql/resolvers/getCompaniesResolver.js
@@ -1,11 +1,12 @@
 import { TABLES } from "../environment";
-import { GetMany } from "./resolverHelper";
+import { GetMany, GetFiltered } from "./resolverHelper";
 
 /*
  * Returns a list of companies
  */
 const GetCompaniesResolver = async (db, args) => {
-  return await GetMany(db, TABLES.Company);
+  let results = await GetFiltered(db, TABLES.Company, args.filters);
+  return { edges: results };
 };
 
 export default GetCompaniesResolver;

--- a/src/graphql/resolvers/getCompaniesResolver.test.js
+++ b/src/graphql/resolvers/getCompaniesResolver.test.js
@@ -40,10 +40,13 @@ const testcases = [
         }
       })
     },
+    args: {
+      filters: null
+    },
     expectedDBCalls: {
       scan: { TableName: TABLES.Company }
     },
-    expectedRetValue: companies
+    expectedRetValue: { edges: companies }
   },
   {
     desc: "should return empty array",
@@ -56,18 +59,21 @@ const testcases = [
         }
       })
     },
+    args: {
+      filters: null
+    },
     expectedDBCalls: {
       scan: { TableName: TABLES.Company }
     },
-    expectedRetValue: []
+    expectedRetValue: { edges: [] }
   }
 ];
 
 describe("GetCompaniesResolver", () => {
   testcases.forEach(
-    async ({ db, expectedDBCalls, expectedRetValue, desc }, i) => {
+    async ({ db, args, expectedDBCalls, expectedRetValue, desc }, i) => {
       it(desc, async () => {
-        await expect(GetCompaniesResolver(db)).resolves.toEqual(
+        await expect(GetCompaniesResolver(db, args)).resolves.toEqual(
           expectedRetValue
         );
         Object.keys(expectedDBCalls).forEach(key => {

--- a/src/graphql/resolvers/getCompanyResolver.js
+++ b/src/graphql/resolvers/getCompanyResolver.js
@@ -1,8 +1,8 @@
-import { GetSingle } from "./resolverHelper";
+import { dbQuery } from "./resolverHelper";
 import { TABLES } from "../environment";
 
 const GetCompanyResolver = async (db, args) => {
-  return await GetSingle(db, TABLES.Company, args.id);
+  return await dbQuery(db, TABLES.Company, args.id);
 };
 
 export default GetCompanyResolver;

--- a/src/graphql/resolvers/getMajorsResolver.js
+++ b/src/graphql/resolvers/getMajorsResolver.js
@@ -1,11 +1,11 @@
 import { TABLES } from "../environment";
-import { GetMany } from "./resolverHelper";
+import { GetFiltered } from "./resolverHelper";
 /*
  * Returns a list of majors
  */
 
 const GetMajorsResolver = async (db, args) => {
-  let students = await GetMany(db, TABLES.Student);
+  let students = await GetFiltered(db, TABLES.Student, args.filters);
   let majors = new Set();
   for (let i in students) {
     majors.add(students[i].major);

--- a/src/graphql/resolvers/getMajorsResolver.js
+++ b/src/graphql/resolvers/getMajorsResolver.js
@@ -1,11 +1,11 @@
 import { TABLES } from "../environment";
-import { GetFiltered } from "./resolverHelper";
+import { dbScan } from "./resolverHelper";
 /*
  * Returns a list of majors
  */
 
 const GetMajorsResolver = async (db, args) => {
-  let students = await GetFiltered(db, TABLES.Student, args.filters);
+  let students = await dbScan(db, TABLES.Student, args.filters);
   let majors = new Set();
   for (let i in students) {
     majors.add(students[i].major);

--- a/src/graphql/resolvers/getMajorsResolver.test.js
+++ b/src/graphql/resolvers/getMajorsResolver.test.js
@@ -15,6 +15,9 @@ const majors = ["Computer Science", "Electrical Engineering"];
 const testcases = [
   {
     desc: "should return all majors",
+    args: {
+      filters: null
+    },
     db: {
       scan: jest.fn().mockReturnValue({
         promise: () => {
@@ -31,6 +34,9 @@ const testcases = [
   },
   {
     desc: "should return empty array",
+    args: {
+      filters: null
+    },
     db: {
       scan: jest.fn().mockReturnValue({
         promise: () => {
@@ -49,9 +55,11 @@ const testcases = [
 
 describe("GetMajorsResolver", () => {
   testcases.forEach(
-    async ({ db, expectedDBCalls, expectedRetValue, desc }, i) => {
+    async ({ db, args, expectedDBCalls, expectedRetValue, desc }, i) => {
       it(desc, async () => {
-        await expect(GetMajorsResolver(db)).resolves.toEqual(expectedRetValue);
+        await expect(GetMajorsResolver(db, args)).resolves.toEqual(
+          expectedRetValue
+        );
         Object.keys(expectedDBCalls).forEach(key => {
           const expected = expectedDBCalls[key];
           expect(db[key].mock.calls[0][0]).toEqual(expected);

--- a/src/graphql/resolvers/getOfferResolver.js
+++ b/src/graphql/resolvers/getOfferResolver.js
@@ -1,8 +1,8 @@
-import { GetSingle } from "./resolverHelper";
+import { dbQuery } from "./resolverHelper";
 import { TABLES } from "../environment";
 
 const GetOfferResolver = async (db, args) => {
-  return await GetSingle(db, TABLES.Offer, args.id);
+  return await dbQuery(db, TABLES.Offer, args.id);
 };
 
 export default GetOfferResolver;

--- a/src/graphql/resolvers/getOfferResolver.test.js
+++ b/src/graphql/resolvers/getOfferResolver.test.js
@@ -1,72 +1,76 @@
 import GetOfferResolver from "./getOfferResolver";
 
-describe("Resolvers", () => {
-  it("GetOfferResolver", async () => {
-    const testcases = [
-      {
-        desc: "should return offer object with the given args and a uuid",
-        db: {
-          get: jest.fn().mockReturnValue({
-            promise: () => {
-              return {
-                Item: {
-                  id: "54321",
-                  position_type: "Full-Time",
-                  position_title: "Janitor"
-                }
-              };
+const testcases = [
+  {
+    desc: "should return offer object with the given args and a uuid",
+    db: {
+      get: jest.fn().mockReturnValue({
+        promise: () => {
+          return {
+            Item: {
+              id: "54321",
+              position_type: "Full-Time",
+              position_title: "Janitor"
             }
-          })
-        },
-        args: {
-          id: "54321"
-        },
-        expectedDBCall: {
-          TableName: "OfferDev",
-          Key: {
-            id: "54321"
-          }
-        },
-        expectedRetValue: {
-          id: "54321",
-          position_type: "Full-Time",
-          position_title: "Janitor"
+          };
         }
-      },
-      {
-        desc: "shouldn't return an offer",
-        db: {
-          get: jest.fn().mockReturnValue({
-            promise: () => {
-              return {
-                Item: null
-              };
-            }
-          })
-        },
-        args: {
-          id: "1423"
-        },
-        expectedDBCall: {
-          TableName: "OfferDev",
-          Key: {
-            id: "1423"
-          }
-        },
-        expectedRetValue: {}
+      })
+    },
+    args: {
+      id: "54321"
+    },
+    expectedDBCall: {
+      get: {
+        TableName: "OfferDev",
+        Key: {
+          id: "54321"
+        }
       }
-    ];
+    },
+    expectedRetValue: {
+      id: "54321",
+      position_type: "Full-Time",
+      position_title: "Janitor"
+    }
+  },
+  {
+    desc: "shouldn't return an offer",
+    db: {
+      get: jest.fn().mockReturnValue({
+        promise: () => {
+          return {
+            Item: null
+          };
+        }
+      })
+    },
+    args: {
+      id: "1423"
+    },
+    expectedDBCall: {
+      get: {
+        TableName: "OfferDev",
+        Key: {
+          id: "1423"
+        }
+      }
+    },
+    expectedRetValue: {}
+  }
+];
 
-    testcases.forEach(
-      async ({ db, args, expectedDBCall, expectedRetValue }, i) => {
+describe("Resolvers", () => {
+  testcases.forEach(
+    async ({ db, args, desc, expectedDBCall, expectedRetValue }, i) => {
+      it(desc, async () => {
         await expect(GetOfferResolver(db, args)).resolves.toEqual(
           expectedRetValue
         );
-        // Object.keys(expectedDBCall).forEach(key => {
-        //   const expected = expectedDBCall[key];
-        //   expect(db[key].mock.calls[0][0]).toEqual(expected);
-        // });
-      }
-    );
-  });
+        Object.keys(expectedDBCall).forEach(key => {
+          const expected = expectedDBCall[key];
+          expect(db[key].mock.calls[0][0]).toEqual(expected);
+        });
+      });
+    }
+  );
 });

--- a/src/graphql/resolvers/getOfferResolver.test.js
+++ b/src/graphql/resolvers/getOfferResolver.test.js
@@ -62,7 +62,10 @@ describe("Resolvers", () => {
         await expect(GetOfferResolver(db, args)).resolves.toEqual(
           expectedRetValue
         );
-        expect(db[key].mock.calls[0][0]).toEqual(expectedDBCall);
+        // Object.keys(expectedDBCall).forEach(key => {
+        //   const expected = expectedDBCall[key];
+        //   expect(db[key].mock.calls[0][0]).toEqual(expected);
+        // });
       }
     );
   });

--- a/src/graphql/resolvers/getOfferResolver.test.js
+++ b/src/graphql/resolvers/getOfferResolver.test.js
@@ -62,7 +62,7 @@ describe("Resolvers", () => {
         await expect(GetOfferResolver(db, args)).resolves.toEqual(
           expectedRetValue
         );
-        expect(db.get.mock.calls[0][0]).toEqual(expectedDBCall);
+        expect(db[key].mock.calls[0][0]).toEqual(expectedDBCall);
       }
     );
   });

--- a/src/graphql/resolvers/getOffersResolver.js
+++ b/src/graphql/resolvers/getOffersResolver.js
@@ -1,26 +1,28 @@
 import { TABLES } from "../environment";
-import { GetMany, GetSingle } from "./resolverHelper";
+import { GetMany, GetSingle, GetFiltered } from "./resolverHelper";
 import removeEmptyStrings from "../utils/removeEmptyStrings";
 import GetCompanyResolver from "./getCompanyResolver";
 
 // Gets all offers
-const GetOffersResolver = async (db, studentId = "") => {
-  let offers;
-  let offerParams = { TableName: TABLES.Offer };
-  if (studentId) {
-    offers = await db
-      .query({
-        ...offerParams,
-        KeyConditionExpression: "student_id = :id",
-        ExpressionAttributeValues: {
-          ":id": studentId
-        }
-      })
-      .promise();
-  } else {
-    offers = await db.scan(offerParams).promise();
-  }
-  offers = offers.Items || [];
+const GetOffersResolver = async (db, args) => {
+  // let offers;
+  // let offerParams = { TableName: TABLES.Offer };
+  // if (studentId) {
+  //   offers = await db
+  //     .query({
+  //       ...offerParams,
+  //       KeyConditionExpression: "student_id = :id",
+  //       ExpressionAttributeValues: {
+  //         ":id": studentId
+  //       }
+  //     })
+  //     .promise();
+  // } else {
+  //   offers = await db.scan(offerParams).promise();
+  // }
+  // offers = offers.Items || [];
+
+  offers = await GetFiltered(db, TABLES.Offer, args.filters);
 
   let res = [];
   for await (let offer of offers) {

--- a/src/graphql/resolvers/getOffersResolver.js
+++ b/src/graphql/resolvers/getOffersResolver.js
@@ -1,11 +1,13 @@
 import { TABLES } from "../environment";
-import { GetMany, GetSingle, GetFiltered } from "./resolverHelper";
+import { dbScan } from "./resolverHelper";
 import removeEmptyStrings from "../utils/removeEmptyStrings";
 import GetCompanyResolver from "./getCompanyResolver";
 
-// Gets all offers
+/*
+ * Returns a list of offers
+ */
 const GetOffersResolver = async (db, args) => {
-  let offers = await GetFiltered(db, TABLES.Offer, args.filters);
+  let offers = await dbScan(db, TABLES.Offer, args.filters);
 
   let res = [];
   for await (let offer of offers) {

--- a/src/graphql/resolvers/getOffersResolver.js
+++ b/src/graphql/resolvers/getOffersResolver.js
@@ -5,24 +5,7 @@ import GetCompanyResolver from "./getCompanyResolver";
 
 // Gets all offers
 const GetOffersResolver = async (db, args) => {
-  // let offers;
-  // let offerParams = { TableName: TABLES.Offer };
-  // if (studentId) {
-  //   offers = await db
-  //     .query({
-  //       ...offerParams,
-  //       KeyConditionExpression: "student_id = :id",
-  //       ExpressionAttributeValues: {
-  //         ":id": studentId
-  //       }
-  //     })
-  //     .promise();
-  // } else {
-  //   offers = await db.scan(offerParams).promise();
-  // }
-  // offers = offers.Items || [];
-
-  offers = await GetFiltered(db, TABLES.Offer, args.filters);
+  let offers = await GetFiltered(db, TABLES.Offer, args.filters);
 
   let res = [];
   for await (let offer of offers) {

--- a/src/graphql/resolvers/getOffersResolver.test.js
+++ b/src/graphql/resolvers/getOffersResolver.test.js
@@ -9,7 +9,10 @@ describe("Resolvers", () => {
         position_title: "Janitor",
         accepted: true,
         academic_year: "Senior",
-        company_name: "Qualtrics",
+        company: {
+          id: "4312",
+          name: "Qualtrics"
+        },
         flag: true,
         student_id: "My student id",
         location: {
@@ -32,6 +35,11 @@ describe("Resolvers", () => {
       }
     ];
 
+    const company = {
+      id: "4312",
+      name: "Qualtrics"
+    };
+
     const testcases = [
       {
         desc: "should return all offer objects",
@@ -47,6 +55,13 @@ describe("Resolvers", () => {
             promise: () => {
               return {
                 Items: bonuses
+              };
+            }
+          }),
+          get: jest.fn().mockReturnValue({
+            promise: () => {
+              return {
+                Item: company
               };
             }
           })

--- a/src/graphql/resolvers/getOffersResolver.test.js
+++ b/src/graphql/resolvers/getOffersResolver.test.js
@@ -66,6 +66,9 @@ describe("Resolvers", () => {
             }
           })
         },
+        args: {
+          filters: null
+        },
         expectedDBCalls: {
           scan: { TableName: "OfferDev" },
           query: {

--- a/src/graphql/resolvers/getOffersResolver.test.js
+++ b/src/graphql/resolvers/getOffersResolver.test.js
@@ -1,98 +1,98 @@
 import GetOffersResolver from "./getOffersResolver";
 
-describe("Resolvers", () => {
-  it("GetOffersResolver", async () => {
-    const offers = [
-      {
-        id: "1234",
-        position_type: "Full-time",
-        position_title: "Janitor",
-        accepted: true,
-        academic_year: "Senior",
-        company: {
-          id: "4312",
-          name: "Qualtrics"
-        },
-        flag: true,
-        student_id: "My student id",
-        location: {
-          city: "Provo",
-          state: "Utah",
-          country: "USA"
-        },
-        wage_value: 123456,
-        wage_type: "salary"
-      }
-    ];
-
-    const bonuses = [
-      {
-        value: 20000,
-        type: "Free money",
-        repeat_count: 5,
-        one_time: false,
-        description: "Just some free money for the new janitor"
-      }
-    ];
-
-    const company = {
+const offers = [
+  {
+    id: "1234",
+    position_type: "Full-time",
+    position_title: "Janitor",
+    accepted: true,
+    academic_year: "Senior",
+    company: {
       id: "4312",
       name: "Qualtrics"
-    };
+    },
+    flag: true,
+    student_id: "My student id",
+    location: {
+      city: "Provo",
+      state: "Utah",
+      country: "USA"
+    },
+    wage_value: 123456,
+    wage_type: "salary"
+  }
+];
 
-    const testcases = [
-      {
-        desc: "should return all offer objects",
-        db: {
-          scan: jest.fn().mockReturnValue({
-            promise: () => {
-              return {
-                Items: offers
-              };
-            }
-          }),
-          query: jest.fn().mockReturnValue({
-            promise: () => {
-              return {
-                Items: bonuses
-              };
-            }
-          }),
-          get: jest.fn().mockReturnValue({
-            promise: () => {
-              return {
-                Item: company
-              };
-            }
-          })
-        },
-        args: {
-          filters: null
-        },
-        expectedDBCalls: {
-          scan: { TableName: "OfferDev" },
-          query: {
-            TableName: "BonusDev",
-            KeyConditionExpression: "#i = :id",
-            ExpressionAttributeNames: { "#i": "id" },
-            ExpressionAttributeValues: {
-              ":id": "1234"
-            }
-          }
-        },
-        expectedRetValue: {
-          edges: [
-            {
-              ...offers[0],
-              bonuses: bonuses
-            }
-          ]
+const bonuses = [
+  {
+    value: 20000,
+    type: "Free money",
+    repeat_count: 5,
+    one_time: false,
+    description: "Just some free money for the new janitor"
+  }
+];
+
+const company = {
+  id: "4312",
+  name: "Qualtrics"
+};
+
+const testcases = [
+  {
+    desc: "should return all offer objects",
+    db: {
+      scan: jest.fn().mockReturnValue({
+        promise: () => {
+          return {
+            Items: offers
+          };
+        }
+      }),
+      query: jest.fn().mockReturnValue({
+        promise: () => {
+          return {
+            Items: bonuses
+          };
+        }
+      }),
+      get: jest.fn().mockReturnValue({
+        promise: () => {
+          return {
+            Item: company
+          };
+        }
+      })
+    },
+    args: {
+      filters: null
+    },
+    expectedDBCalls: {
+      scan: { TableName: "OfferDev" },
+      query: {
+        TableName: "BonusDev",
+        KeyConditionExpression: "#i = :id",
+        ExpressionAttributeNames: { "#i": "id" },
+        ExpressionAttributeValues: {
+          ":id": "1234"
         }
       }
-    ];
+    },
+    expectedRetValue: {
+      edges: [
+        {
+          ...offers[0],
+          bonuses: bonuses
+        }
+      ]
+    }
+  }
+];
 
-    testcases.forEach(
-      async ({ db, args, expectedDBCalls, expectedRetValue }, i) => {
+describe("Resolvers", () => {
+  testcases.forEach(
+    async ({ db, desc, args, expectedDBCalls, expectedRetValue }, i) => {
+      it(desc, async () => {
         await expect(GetOffersResolver(db, args)).resolves.toEqual(
           expectedRetValue
         );
@@ -100,7 +100,7 @@ describe("Resolvers", () => {
           const expected = expectedDBCalls[key];
           expect(db[key].mock.calls[0][0]).toEqual(expected);
         });
-      }
-    );
-  });
+      });
+    }
+  );
 });

--- a/src/graphql/resolvers/getStudentResolver.js
+++ b/src/graphql/resolvers/getStudentResolver.js
@@ -1,8 +1,8 @@
 import { TABLES } from "../environment";
-import { GetSingle } from "./resolverHelper";
+import { dbQuery } from "./resolverHelper";
 
 const GetStudentResolver = async (db, args) => {
-  return await GetSingle(db, TABLES.Student, args.id);
+  return await dbQuery(db, TABLES.Student, args.id);
 };
 
 export default GetStudentResolver;

--- a/src/graphql/resolvers/getStudentResolver.test.js
+++ b/src/graphql/resolvers/getStudentResolver.test.js
@@ -72,7 +72,7 @@ describe("Resolvers", () => {
         await expect(GetStudentResolver(db, args)).resolves.toEqual(
           expectedRetValue
         );
-        expect(db[key].mock.calls[0][0]).toEqual(expectedDBCall);
+        // expect(db.mock.calls[0][0]).toEqual(expectedDBCall);
       }
     );
   });

--- a/src/graphql/resolvers/getStudentResolver.test.js
+++ b/src/graphql/resolvers/getStudentResolver.test.js
@@ -72,7 +72,7 @@ describe("Resolvers", () => {
         await expect(GetStudentResolver(db, args)).resolves.toEqual(
           expectedRetValue
         );
-        expect(db.get.mock.calls[0][0]).toEqual(expectedDBCall);
+        expect(db[key].mock.calls[0][0]).toEqual(expectedDBCall);
       }
     );
   });

--- a/src/graphql/resolvers/getStudentResolver.test.js
+++ b/src/graphql/resolvers/getStudentResolver.test.js
@@ -1,79 +1,78 @@
 import GetStudentResolver from "./getStudentResolver";
 
-describe("Resolvers", () => {
-  it("GetStudentResolver", async () => {
-    const testcases = [
-      {
-        desc: "should return student object with the given args and a uuid",
-        db: {
-          get: jest.fn().mockReturnValue({
-            promise: () => {
-              return {
-                Item: {
-                  id: "132",
-                  email: "test@test.com",
-                  firstname: "John",
-                  lastname: "JingleheimerSchmidt",
-                  college_id: "LDSBC",
-                  academic_year: "Freshman",
-                  major: "Piano Performance",
-                  gender: "Male"
-                }
-              };
+const testcases = [
+  {
+    desc: "should return student object with the given args and a uuid",
+    db: {
+      get: jest.fn().mockReturnValue({
+        promise: () => {
+          return {
+            Item: {
+              id: "132",
+              email: "test@test.com",
+              firstname: "John",
+              lastname: "JingleheimerSchmidt",
+              college_id: "LDSBC",
+              academic_year: "Freshman",
+              major: "Piano Performance",
+              gender: "Male"
             }
-          })
-        },
-        args: {
-          id: "132"
-        },
-        expectedDBCall: {
-          TableName: "StudentDev",
-          Key: {
-            id: "132"
-          }
-        },
-        expectedRetValue: {
-          id: "132",
-          email: "test@test.com",
-          firstname: "John",
-          lastname: "JingleheimerSchmidt",
-          college_id: "LDSBC",
-          academic_year: "Freshman",
-          major: "Piano Performance",
-          gender: "Male"
+          };
         }
-      },
-      {
-        desc: "should return empty object (student not found)",
-        db: {
-          get: jest.fn().mockReturnValue({
-            promise: () => {
-              return {
-                Item: null
-              };
-            }
-          })
-        },
-        args: {
-          id: "12"
-        },
-        expectedDBCall: {
-          TableName: "StudentDev",
-          Key: {
-            id: "12"
-          }
-        },
-        expectedRetValue: {}
+      })
+    },
+    args: {
+      id: "132"
+    },
+    expectedDBCall: {
+      TableName: "StudentDev",
+      Key: {
+        id: "132"
       }
-    ];
-
-    testcases.forEach(
-      async ({ db, args, expectedDBCall, expectedRetValue }, i) => {
+    },
+    expectedRetValue: {
+      id: "132",
+      email: "test@test.com",
+      firstname: "John",
+      lastname: "JingleheimerSchmidt",
+      college_id: "LDSBC",
+      academic_year: "Freshman",
+      major: "Piano Performance",
+      gender: "Male"
+    }
+  },
+  {
+    desc: "should return empty object (student not found)",
+    db: {
+      get: jest.fn().mockReturnValue({
+        promise: () => {
+          return {
+            Item: null
+          };
+        }
+      })
+    },
+    args: {
+      id: "12"
+    },
+    expectedDBCall: {
+      TableName: "StudentDev",
+      Key: {
+        id: "12"
+      }
+    },
+    expectedRetValue: {}
+  }
+];
+describe("Resolvers", () => {
+  testcases.forEach(
+    async ({ db, desc, args, expectedDBCall, expectedRetValue }, i) => {
+      it(desc, async () => {
         await expect(GetStudentResolver(db, args)).resolves.toEqual(
           expectedRetValue
         );
-        // expect(db.mock.calls[0][0]).toEqual(expectedDBCall);
-      }
-    );
-  });
+        await expect(db.get.mock.calls[0][0]).toEqual(expectedDBCall);
+      });
+    }
+  );
 });

--- a/src/graphql/resolvers/getStudentsResolver.js
+++ b/src/graphql/resolvers/getStudentsResolver.js
@@ -1,9 +1,9 @@
 import { TABLES } from "../environment";
-import { GetMany, GetFiltered } from "./resolverHelper";
+import { dbScan } from "./resolverHelper";
 
 // Gets all students
 const GetStudentsResolver = async (db, args) => {
-  const res = await GetFiltered(db, TABLES.Student, args.filters);
+  const res = await dbScan(db, TABLES.Student, args.filters);
   return { edges: res };
 };
 

--- a/src/graphql/resolvers/getStudentsResolver.js
+++ b/src/graphql/resolvers/getStudentsResolver.js
@@ -1,9 +1,9 @@
 import { TABLES } from "../environment";
-import { GetMany } from "./resolverHelper";
+import { GetMany, GetFiltered } from "./resolverHelper";
 
 // Gets all students
 const GetStudentsResolver = async (db, args) => {
-  const res = await GetMany(db, TABLES.Student);
+  const res = await GetFiltered(db, TABLES.Student, args.filters);
   return { edges: res };
 };
 

--- a/src/graphql/resolvers/getStudentsResolver.test.js
+++ b/src/graphql/resolvers/getStudentsResolver.test.js
@@ -1,66 +1,66 @@
 import GetStudentsResolver from "./getStudentsResolver";
 
+const students = [
+  {
+    email: "studentemail@test.com",
+    firstname: "Johnny",
+    lastname: "Student",
+    college_id: "BYUID",
+    academic_year: "Junior",
+    major: "Chemical Engineering"
+  }
+];
+
+const testcases = [
+  {
+    desc: "should return all students",
+    db: {
+      scan: jest.fn().mockReturnValue({
+        promise: () => {
+          return {
+            Items: students
+          };
+        }
+      })
+    },
+    args: {
+      filters: null
+    },
+    expectedDBCall: {
+      TableName: "StudentDev"
+    },
+    expectedRetValue: { edges: students }
+  },
+  {
+    desc: "shouldn't return students",
+    db: {
+      scan: jest.fn().mockReturnValue({
+        promise: () => {
+          return {
+            Items: null
+          };
+        }
+      })
+    },
+    args: {
+      filters: null
+    },
+    expectedDBCall: {
+      TableName: "StudentDev"
+    },
+    expectedRetValue: { edges: [] }
+  }
+];
+
 describe("Resolvers", () => {
-  it("GetStudentsResolver", async () => {
-    const students = [
-      {
-        email: "studentemail@test.com",
-        firstname: "Johnny",
-        lastname: "Student",
-        college_id: "BYUID",
-        academic_year: "Junior",
-        major: "Chemical Engineering"
-      }
-    ];
-
-    const testcases = [
-      {
-        desc: "should return all students",
-        db: {
-          scan: jest.fn().mockReturnValue({
-            promise: () => {
-              return {
-                Items: students
-              };
-            }
-          })
-        },
-        args: {
-          filters: null
-        },
-        expectedDBCall: {
-          TableName: "StudentDev"
-        },
-        expectedRetValue: { edges: students }
-      },
-      {
-        desc: "shouldn't return students",
-        db: {
-          scan: jest.fn().mockReturnValue({
-            promise: () => {
-              return {
-                Items: null
-              };
-            }
-          })
-        },
-        args: {
-          filters: null
-        },
-        expectedDBCall: {
-          TableName: "StudentDev"
-        },
-        expectedRetValue: { edges: [] }
-      }
-    ];
-
-    testcases.forEach(
-      async ({ db, args, expectedDBCall, expectedRetValue }, i) => {
+  testcases.forEach(
+    async ({ db, desc, args, expectedDBCall, expectedRetValue }, i) => {
+      it(desc, async () => {
         await expect(GetStudentsResolver(db, args)).resolves.toEqual(
           expectedRetValue
         );
         expect(db.scan.mock.calls[0][0]).toEqual(expectedDBCall);
-      }
-    );
-  });
+      });
+    }
+  );
 });

--- a/src/graphql/resolvers/getStudentsResolver.test.js
+++ b/src/graphql/resolvers/getStudentsResolver.test.js
@@ -28,7 +28,7 @@ describe("Resolvers", () => {
         expectedDBCall: {
           TableName: "StudentDev"
         },
-        expectedRetValue: students
+        expectedRetValue: { edges: students }
       },
       {
         desc: "shouldn't return students",
@@ -44,7 +44,7 @@ describe("Resolvers", () => {
         expectedDBCall: {
           TableName: "StudentDev"
         },
-        expectedRetValue: []
+        expectedRetValue: { edges: [] }
       }
     ];
 

--- a/src/graphql/resolvers/getStudentsResolver.test.js
+++ b/src/graphql/resolvers/getStudentsResolver.test.js
@@ -25,6 +25,9 @@ describe("Resolvers", () => {
             }
           })
         },
+        args: {
+          filters: null
+        },
         expectedDBCall: {
           TableName: "StudentDev"
         },
@@ -40,6 +43,9 @@ describe("Resolvers", () => {
               };
             }
           })
+        },
+        args: {
+          filters: null
         },
         expectedDBCall: {
           TableName: "StudentDev"

--- a/src/graphql/resolvers/postOfferResolver.test.js
+++ b/src/graphql/resolvers/postOfferResolver.test.js
@@ -6,6 +6,8 @@ describe("Resolvers", () => {
   });
 
   it("PostOfferResolver", async () => {
+    const time = new Date("2019");
+    global.Date = jest.fn(() => time);
     const testValues = [
       {
         offer: {
@@ -15,8 +17,8 @@ describe("Resolvers", () => {
           academic_year: "Senior",
           company_name: "test",
           company_id: "coolcompanyid",
-          flag: false,
           student_id: "mylord",
+          timestamp: time.getTime(),
           wage_value: 1
         },
         location: {

--- a/src/graphql/resolvers/postOfferResolver.test.js
+++ b/src/graphql/resolvers/postOfferResolver.test.js
@@ -1,143 +1,141 @@
 import PostOfferResolver from "./postOfferResolver";
 
+const time = new Date("2019");
+global.Date = jest.fn(() => time);
+const testValues = [
+  {
+    offer: {
+      position_type: "Part-Time",
+      position_title: "King",
+      accepted: true,
+      academic_year: "Senior",
+      company_name: "test",
+      company_id: "coolcompanyid",
+      student_id: "mylord",
+      timestamp: time.getTime(),
+      wage_value: 1
+    },
+    location: {
+      city: "London",
+      state: "State",
+      country: "England"
+    },
+    bonuses: [
+      {
+        value: 12345,
+        type: "",
+        one_time: true,
+        description: "A really cool bonus"
+      }
+    ],
+    location_id: "LondonStateEngland".replace(/\s/g, "")
+  }
+];
+const testcases = [
+  {
+    desc: "should post an offer and the new company object with the given args",
+    db: {
+      query: jest.fn().mockReturnValue({
+        promise: () => {
+          return {};
+        }
+      }),
+      put: jest.fn().mockReturnValue({
+        promise: () => {
+          return {
+            Items: [
+              {
+                name: "test",
+                id: "coolcompanyid"
+              }
+            ]
+          };
+        }
+      }),
+      // query location
+      query: jest.fn().mockReturnValue({
+        promise: () => {
+          return {
+            Items: [
+              {
+                name: "test",
+                id: "coolcompanyid"
+              }
+            ]
+          };
+        }
+      })
+    },
+    args: {
+      offer: {
+        ...testValues[0].offer,
+        location: testValues[0].location,
+        bonuses: testValues[0].bonuses
+      }
+    },
+    expectedRetValue: {
+      ...testValues[0].offer,
+      id: 123456789,
+      location_id: testValues[0].location_id
+    }
+  },
+  {
+    desc:
+      "should post an offer object with the given args but not post the company object",
+    db: {
+      put: jest.fn().mockReturnValue({
+        promise: () => {
+          return { Items: [{ name: "" }] };
+        }
+      }),
+      // query location
+      query: jest.fn().mockReturnValue({
+        promise: () => {
+          return {
+            Items: [
+              {
+                id: "coolcompanyid",
+                name: "test"
+              }
+            ]
+          };
+        }
+      })
+    },
+    args: {
+      offer: {
+        ...testValues[0].offer,
+        location: testValues[0].location
+      }
+    },
+    expectedRetValue: {
+      ...testValues[0].offer,
+      id: 123456789,
+      location_id: testValues[0].location_id
+    }
+  },
+  {
+    desc: "should catch an error thrown",
+    db: {
+      query: jest.fn().mockImplementation(() => {
+        throw new Error("I broke");
+      })
+    },
+    args: {
+      offer: {
+        ...testValues[0].offer
+      }
+    },
+    expectedRetValue: {}
+  }
+];
+
 describe("Resolvers", () => {
   beforeEach(() => {
     jest.spyOn(console, "error").mockImplementation(() => {});
   });
-
-  it("PostOfferResolver", async () => {
-    const time = new Date("2019");
-    global.Date = jest.fn(() => time);
-    const testValues = [
-      {
-        offer: {
-          position_type: "Part-Time",
-          position_title: "King",
-          accepted: true,
-          academic_year: "Senior",
-          company_name: "test",
-          company_id: "coolcompanyid",
-          student_id: "mylord",
-          timestamp: time.getTime(),
-          wage_value: 1
-        },
-        location: {
-          city: "London",
-          state: "State",
-          country: "England"
-        },
-        bonuses: [
-          {
-            value: 12345,
-            type: "",
-            one_time: true,
-            description: "A really cool bonus"
-          }
-        ],
-        location_id: "LondonStateEngland".replace(/\s/g, "")
-      }
-    ];
-    const testcases = [
-      {
-        desc:
-          "should post an offer and the new company object with the given args",
-        db: {
-          query: jest.fn().mockReturnValue({
-            promise: () => {
-              return {};
-            }
-          }),
-          put: jest.fn().mockReturnValue({
-            promise: () => {
-              return {
-                Items: [
-                  {
-                    name: "test",
-                    id: "coolcompanyid"
-                  }
-                ]
-              };
-            }
-          }),
-          // query location
-          query: jest.fn().mockReturnValue({
-            promise: () => {
-              return {
-                Items: [
-                  {
-                    name: "test",
-                    id: "coolcompanyid"
-                  }
-                ]
-              };
-            }
-          })
-        },
-        args: {
-          offer: {
-            ...testValues[0].offer,
-            location: testValues[0].location,
-            bonuses: testValues[0].bonuses
-          }
-        },
-        expectedRetValue: {
-          ...testValues[0].offer,
-          id: 123456789,
-          location_id: testValues[0].location_id
-        }
-      },
-      {
-        desc:
-          "should post an offer object with the given args but not post the company object",
-        db: {
-          put: jest.fn().mockReturnValue({
-            promise: () => {
-              return { Items: [{ name: "" }] };
-            }
-          }),
-          // query location
-          query: jest.fn().mockReturnValue({
-            promise: () => {
-              return {
-                Items: [
-                  {
-                    id: "coolcompanyid",
-                    name: "test"
-                  }
-                ]
-              };
-            }
-          })
-        },
-        args: {
-          offer: {
-            ...testValues[0].offer,
-            location: testValues[0].location
-          }
-        },
-        expectedRetValue: {
-          ...testValues[0].offer,
-          id: 123456789,
-          location_id: testValues[0].location_id
-        }
-      },
-      {
-        desc: "should catch an error thrown",
-        db: {
-          query: jest.fn().mockImplementation(() => {
-            throw new Error("I broke");
-          })
-        },
-        args: {
-          offer: {
-            ...testValues[0].offer
-          }
-        },
-        expectedRetValue: {}
-      }
-    ];
-
-    testcases.forEach(async ({ db, args, expectedRetValue }, i) => {
+  testcases.forEach(async ({ db, desc, args, expectedRetValue }, i) => {
+    it(desc, async () => {
       await expect(PostOfferResolver(db, args)).resolves.toEqual(
         expect.objectContaining(expectedRetValue)
       );

--- a/src/graphql/resolvers/postStudentResolver.test.js
+++ b/src/graphql/resolvers/postStudentResolver.test.js
@@ -1,43 +1,42 @@
 import PostStudentResolver from "./postStudentResolver";
 
-describe("Resolvers", () => {
-  it("PostStudentResolver", async () => {
-    const testcases = [
-      {
-        desc: "should return student object with the given args and a uuid",
-        db: {
-          put: jest.fn().mockReturnValue({ promise: () => {} })
-        },
-        args: {
-          student: {
-            id: "thisisauniqueid",
-            firstname: "Braden",
-            lastname: "Watkins"
-          }
-        },
-        expectedDBCall: {
-          TableName: "StudentDev",
-          Item: {
-            id: "thisisauniqueid",
-            firstname: "Braden",
-            lastname: "Watkins"
-          }
-        },
-        expectedRetValue: {
-          id: "thisisauniqueid",
-          firstname: "Braden",
-          lastname: "Watkins"
-        }
+const testcases = [
+  {
+    desc: "should return student object with the given args and a uuid",
+    db: {
+      put: jest.fn().mockReturnValue({ promise: () => {} })
+    },
+    args: {
+      student: {
+        id: "thisisauniqueid",
+        firstname: "Braden",
+        lastname: "Watkins"
       }
-    ];
-
-    testcases.forEach(
-      async ({ db, args, expectedDBCall, expectedRetValue }, i) => {
+    },
+    expectedDBCall: {
+      TableName: "StudentDev",
+      Item: {
+        id: "thisisauniqueid",
+        firstname: "Braden",
+        lastname: "Watkins"
+      }
+    },
+    expectedRetValue: {
+      id: "thisisauniqueid",
+      firstname: "Braden",
+      lastname: "Watkins"
+    }
+  }
+];
+describe("Resolvers", () => {
+  testcases.forEach(
+    async ({ db, args, desc, expectedDBCall, expectedRetValue }, i) => {
+      it(desc, async () => {
         await expect(PostStudentResolver(db, args)).resolves.toEqual(
           expectedRetValue
         );
         expect(db.put.mock.calls[i][0]).toEqual(expectedDBCall);
-      }
-    );
-  });
+      });
+    }
+  );
 });

--- a/src/graphql/resolvers/resolverHelper.js
+++ b/src/graphql/resolvers/resolverHelper.js
@@ -17,25 +17,29 @@ const GetMany = async (db, table) => {
   return results.Items || [];
 };
 
-const GetFiltered = async (db, table, filters = []) => {
-  let KeyCondition = "";
-  let Expression = {};
+const GetFiltered = async (db, table, filters) => {
+  let FilterExpression;
+  let ExpressionAttributeValues;
 
-  for (temp in filters) {
-    const item = temp.field;
-    const value = temp.value;
-    const comp = temp.comp;
-    Expression[`:${item}`] = { S: value };
-    KeyCondition += `${item} ${comp} :${item} `;
+  if (filters) {
+    ExpressionAttributeValues = {};
+    FilterExpression = "";
+    for (let i in filters) {
+      const item = filters[i].field;
+      const value = filters[i].value;
+      const comp = filters[i].comp;
+      ExpressionAttributeValues[`:${item}`] = value;
+      FilterExpression += `${item} ${comp} :${item} `;
+    }
   }
 
   const params = {
     TableName: table,
-    ExpressionAttributeValues: Expression,
-    KeyConditionExpression: KeyCondition
+    FilterExpression,
+    ExpressionAttributeValues
   };
 
-  results = await db.scan(params).promise();
+  let results = await db.scan(params).promise();
   return results.Items || [];
 };
 

--- a/src/graphql/resolvers/resolverHelper.js
+++ b/src/graphql/resolvers/resolverHelper.js
@@ -22,7 +22,7 @@ const dbScan = async (db, table, filters) => {
       const comp = filters[i].comp;
       ExpressionAttributeValues[`:${item}`] = value;
       FilterExpression += `${item} ${comp} :${item}`;
-      if (i < filters.length) {
+      if (i < filters.length - 1) {
         FilterExpression += ", ";
       }
     }

--- a/src/graphql/resolvers/resolverHelper.js
+++ b/src/graphql/resolvers/resolverHelper.js
@@ -1,4 +1,4 @@
-const GetSingle = async (db, table, item_id) => {
+const dbQuery = async (db, table, item_id) => {
   const params = {
     TableName: table,
     Key: {
@@ -9,15 +9,7 @@ const GetSingle = async (db, table, item_id) => {
   return response.Item || {};
 };
 
-const GetMany = async (db, table) => {
-  const params = {
-    TableName: table
-  };
-  let results = await db.scan(params).promise();
-  return results.Items || [];
-};
-
-const GetFiltered = async (db, table, filters) => {
+const dbScan = async (db, table, filters) => {
   let FilterExpression;
   let ExpressionAttributeValues;
 
@@ -29,7 +21,10 @@ const GetFiltered = async (db, table, filters) => {
       const value = filters[i].value;
       const comp = filters[i].comp;
       ExpressionAttributeValues[`:${item}`] = value;
-      FilterExpression += `${item} ${comp} :${item} `;
+      FilterExpression += `${item} ${comp} :${item}`;
+      if (i < filters.length) {
+        FilterExpression += ", ";
+      }
     }
   }
 
@@ -43,4 +38,4 @@ const GetFiltered = async (db, table, filters) => {
   return results.Items || [];
 };
 
-export { GetSingle, GetMany, GetFiltered };
+export { dbQuery, dbScan };

--- a/src/graphql/resolvers/resolverHelper.js
+++ b/src/graphql/resolvers/resolverHelper.js
@@ -17,4 +17,26 @@ const GetMany = async (db, table) => {
   return results.Items || [];
 };
 
-export { GetSingle, GetMany };
+const GetFiltered = async (db, table, filters = []) => {
+  let KeyCondition = "";
+  let Expression = {};
+
+  for (temp in filters) {
+    const item = temp.field;
+    const value = temp.value;
+    const comp = temp.comp;
+    Expression[`:${item}`] = { S: value };
+    KeyCondition += `${item} ${comp} :${item} `;
+  }
+
+  const params = {
+    TableName: table,
+    ExpressionAttributeValues: Expression,
+    KeyConditionExpression: KeyCondition
+  };
+
+  results = await db.scan(params).promise();
+  return results.Items || [];
+};
+
+export { GetSingle, GetMany, GetFiltered };

--- a/src/graphql/resolvers/resolverHelper.test.js
+++ b/src/graphql/resolvers/resolverHelper.test.js
@@ -1,4 +1,4 @@
-import { GetMany, GetSingle, GetFiltered } from "./resolverHelper";
+import { dbQuery, dbScan } from "./resolverHelper";
 
 it("should build filter params for dynamoDB", () => {
   const table = "StudentDev";
@@ -45,7 +45,7 @@ it("should build filter params for dynamoDB", () => {
 
   testCases.forEach(async ({ params, expectedDBCall, expectedRetValue }) => {
     await expect(
-      GetFiltered(params.db, params.table, params.filters)
+      dbScan(params.db, params.table, params.filters)
     ).resolves.toEqual(expectedRetValue);
     expect(db.scan.mock.calls[i][0]).toEqual(expectedDBCall);
   });

--- a/src/graphql/resolvers/resolverHelper.test.js
+++ b/src/graphql/resolvers/resolverHelper.test.js
@@ -1,23 +1,52 @@
-// import { GetMany, GetSingle, BuildFilterParams } from "./resolverHelper";
+import { GetMany, GetSingle, GetFiltered } from "./resolverHelper";
 
-// it("should build filter params for dynamoDB", () => {
-//   const testCases = [
-//     {
-//       description: "should pull single param from object",
-//       params: { field: "student_id", value: "123456789" },
-//       expected: {
-//         KeyConditionExpression: "#student_id = :student_id",
-//         ExpressionAttributeNames: {
-//           "#student_id": "student_id"
-//         },
-//         ExpressionAttributeValues: {
-//           ":student_id": "123456789"
-//         }
-//       }
-//     }
-//   ];
+it("should build filter params for dynamoDB", () => {
+  const table = "StudentDev";
+  const testCases = [
+    {
+      description: "should pull single param from object",
+      params: {
+        db: {
+          scan: jest.fn().mockReturnValue({
+            promise: () => {
+              return {
+                Items: {
+                  id: "thisisauniqueid",
+                  firstname: "Braden",
+                  lastname: "Watkins"
+                }
+              };
+            }
+          })
+        },
+        table: table,
+        filters: [
+          {
+            field: "student_id",
+            value: "123456789",
+            comp: "="
+          }
+        ]
+      },
+      expectedDBCall: {
+        TableName: table,
+        FilterExpression: "student_id = :student_id",
+        ExpressionAttributeValues: {
+          ":student_id": "123456789"
+        }
+      },
+      expectedRetValue: {
+        id: "thisisauniqueid",
+        firstname: "Braden",
+        lastname: "Watkins"
+      }
+    }
+  ];
 
-//   testCases.forEach(({ params, expected }) => {
-//     expect(BuildFilterParams(params)).toEqual(expected);
-//   });
-// });
+  testCases.forEach(async ({ params, expectedDBCall, expectedRetValue }) => {
+    await expect(
+      GetFiltered(params.db, params.table, params.filters)
+    ).resolves.toEqual(expectedRetValue);
+    expect(db.scan.mock.calls[i][0]).toEqual(expectedDBCall);
+  });
+});

--- a/src/graphql/resolvers/resolverHelper.test.js
+++ b/src/graphql/resolvers/resolverHelper.test.js
@@ -1,23 +1,23 @@
-import { GetMany, GetSingle, BuildFilterParams } from "./resolverHelper";
+// import { GetMany, GetSingle, BuildFilterParams } from "./resolverHelper";
 
-it("should build filter params for dynamoDB", () => {
-  const testCases = [
-    {
-      description: "should pull single param from object",
-      params: { field: "student_id", value: "123456789" },
-      expected: {
-        KeyConditionExpression: "#student_id = :student_id",
-        ExpressionAttributeNames: {
-          "#student_id": "student_id"
-        },
-        ExpressionAttributeValues: {
-          ":student_id": "123456789"
-        }
-      }
-    }
-  ];
+// it("should build filter params for dynamoDB", () => {
+//   const testCases = [
+//     {
+//       description: "should pull single param from object",
+//       params: { field: "student_id", value: "123456789" },
+//       expected: {
+//         KeyConditionExpression: "#student_id = :student_id",
+//         ExpressionAttributeNames: {
+//           "#student_id": "student_id"
+//         },
+//         ExpressionAttributeValues: {
+//           ":student_id": "123456789"
+//         }
+//       }
+//     }
+//   ];
 
-  testCases.forEach(({ params, expected }) => {
-    expect(BuildFilterParams(params)).toEqual(expected);
-  });
-});
+//   testCases.forEach(({ params, expected }) => {
+//     expect(BuildFilterParams(params)).toEqual(expected);
+//   });
+// });

--- a/src/graphql/resolvers/resolverHelper.test.js
+++ b/src/graphql/resolvers/resolverHelper.test.js
@@ -1,6 +1,6 @@
 import { dbQuery, dbScan } from "./resolverHelper";
 
-it("should build filter params for dynamoDB", () => {
+describe("Resolver Helpers", () => {
   const table = "StudentDev";
   const testCases = [
     {
@@ -43,10 +43,14 @@ it("should build filter params for dynamoDB", () => {
     }
   ];
 
-  testCases.forEach(async ({ params, expectedDBCall, expectedRetValue }) => {
-    await expect(
-      dbScan(params.db, params.table, params.filters)
-    ).resolves.toEqual(expectedRetValue);
-    expect(db.scan.mock.calls[i][0]).toEqual(expectedDBCall);
-  });
+  testCases.forEach(
+    async ({ params, description, expectedDBCall, expectedRetValue }) => {
+      it(description, async () => {
+        await expect(
+          dbScan(params.db, params.table, params.filters)
+        ).resolves.toEqual(expectedRetValue);
+        expect(params.db.scan.mock.calls[0][0]).toEqual(expectedDBCall);
+      });
+    }
+  );
 });

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -56,18 +56,24 @@ let Schema = db => {
       },
       offers: {
         type: OfferConnection,
-        resolve: async _ => GetOffersResolver(db)
+        args: {
+          filters: { type: GraphQLList(FilterType) }
+        },
+        resolve: async (_, args) => GetOffersResolver(db, args)
       },
       students: {
         type: StudentConnection,
         args: {
-          gender: { type: GraphQLString }
+          filters: { type: GraphQLList(FilterType) }
         },
         resolve: async (_, args) => GetStudentsResolver(db, args)
       },
       company_names: {
         type: GraphQLList(GraphQLString),
-        resolve: async _ => GetCompanyNamesResolver(db)
+        args: {
+          filters: { type: GraphQLList(FilterType) }
+        },
+        resolve: async (_, args) => GetCompanyNamesResolver(db, args)
       },
       companies: {
         type: CompanyConnection,
@@ -85,6 +91,9 @@ let Schema = db => {
       },
       majors: {
         type: GraphQLList(GraphQLString),
+        args: {
+          filters: { type: GraphQLList(FilterType) }
+        },
         resolve: async (_, args) => GetMajorsResolver(db, args)
       }
     })

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -3,7 +3,8 @@ import {
   GraphQLObjectType,
   GraphQLString,
   GraphQLSchema,
-  GraphQLList
+  GraphQLList,
+  GraphQLInputType
 } from "graphql";
 
 import {
@@ -16,7 +17,9 @@ import {
   CompanyType,
   CompanyConnection,
   LocationConnection,
-  BonusConnection
+  BonusConnection,
+  Filters,
+  FilterType
 } from "./types";
 
 import {
@@ -68,6 +71,9 @@ let Schema = db => {
       },
       companies: {
         type: CompanyConnection,
+        args: {
+          filters: { type: GraphQLList(FilterType) }
+        },
         resolve: async (_, args) => GetCompaniesResolver(db, args)
       },
       company: {

--- a/src/graphql/schema.js
+++ b/src/graphql/schema.js
@@ -13,7 +13,10 @@ import {
   OfferType,
   CreateStudentInput,
   CreateOfferInput,
-  CompanyType
+  CompanyType,
+  CompanyConnection,
+  LocationConnection,
+  BonusConnection
 } from "./types";
 
 import {
@@ -64,7 +67,7 @@ let Schema = db => {
         resolve: async _ => GetCompanyNamesResolver(db)
       },
       companies: {
-        type: GraphQLList(CompanyType),
+        type: CompanyConnection,
         resolve: async (_, args) => GetCompaniesResolver(db, args)
       },
       company: {

--- a/src/graphql/types/bonusType.js
+++ b/src/graphql/types/bonusType.js
@@ -26,4 +26,11 @@ const BonusInput = new GraphQLInputObjectType({
   fields: () => bonus
 });
 
-export { BonusInput, BonusType };
+const BonusConnection = new GraphQLObjectType({
+  name: "bonusConnection",
+  fields: () => ({
+    edges: { type: GraphQLList(BonusType) }
+  })
+});
+
+export { BonusInput, BonusType, BonusConnection };

--- a/src/graphql/types/bonusType.js
+++ b/src/graphql/types/bonusType.js
@@ -4,7 +4,8 @@ import {
   GraphQLBoolean,
   GraphQLInputObjectType,
   GraphQLFloat,
-  GraphQLInt
+  GraphQLInt,
+  GraphQLList
 } from "graphql";
 
 const bonus = {

--- a/src/graphql/types/companyType.js
+++ b/src/graphql/types/companyType.js
@@ -10,4 +10,11 @@ const CompanyType = new GraphQLObjectType({
   fields: () => company
 });
 
-export { CompanyType };
+const CompanyConnection = new GraphQLObjectType({
+  name: "companyConnection",
+  fields: () => ({
+    edges: { type: GraphQLList(CompanyType) }
+  })
+});
+
+export { CompanyType, CompanyConnection };

--- a/src/graphql/types/companyType.js
+++ b/src/graphql/types/companyType.js
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLString } from "graphql";
+import { GraphQLObjectType, GraphQLString, GraphQLList } from "graphql";
 
 const company = {
   id: { type: GraphQLString },

--- a/src/graphql/types/filterType.js
+++ b/src/graphql/types/filterType.js
@@ -1,0 +1,19 @@
+import { GraphQLString, GraphQLList, GraphQLInputObjectType } from "graphql";
+
+const filter = {
+  field: { type: GraphQLString },
+  value: { type: GraphQLString },
+  comp: { type: GraphQLString }
+};
+
+const FilterType = new GraphQLInputObjectType({
+  name: "filter",
+  fields: () => filter
+});
+
+const Filters = new GraphQLInputObjectType({
+  name: "filters",
+  fields: () => GraphQLList(FilterType)
+});
+
+export { FilterType, Filters };

--- a/src/graphql/types/index.js
+++ b/src/graphql/types/index.js
@@ -11,3 +11,4 @@ export {
   CreateStudentInput
 } from "./studentType";
 export { CompanyType, CompanyConnection } from "./companyType";
+export { Filters, FilterType } from "./filterType";

--- a/src/graphql/types/index.js
+++ b/src/graphql/types/index.js
@@ -1,9 +1,13 @@
-export { BonusInput, BonusType } from "./bonusType";
-export { LocationInput, LocationType } from "./locationType";
+export { BonusInput, BonusType, BonusConnection } from "./bonusType";
+export {
+  LocationInput,
+  LocationType,
+  LocationConnection
+} from "./locationType";
 export { OfferConnection, OfferType, CreateOfferInput } from "./offerType";
 export {
   StudentType,
   StudentConnection,
   CreateStudentInput
 } from "./studentType";
-export { CompanyType } from "./companyType";
+export { CompanyType, CompanyConnection } from "./companyType";

--- a/src/graphql/types/locationType.js
+++ b/src/graphql/types/locationType.js
@@ -1,7 +1,8 @@
 import {
   GraphQLObjectType,
   GraphQLString,
-  GraphQLInputObjectType
+  GraphQLInputObjectType,
+  GraphQLList
 } from "graphql";
 
 const location = {

--- a/src/graphql/types/locationType.js
+++ b/src/graphql/types/locationType.js
@@ -20,4 +20,11 @@ const LocationInput = new GraphQLInputObjectType({
   fields: () => location
 });
 
-export { LocationInput, LocationType };
+const LocationConnection = new GraphQLObjectType({
+  name: "locationConnection",
+  fields: () => ({
+    edges: { type: GraphQLList(LocationConnection) }
+  })
+});
+
+export { LocationInput, LocationType, LocationConnection };

--- a/src/graphql/utils/removeEmptyStrings.test.js
+++ b/src/graphql/utils/removeEmptyStrings.test.js
@@ -1,22 +1,21 @@
 import removeEmptyStrings from "./removeEmptyStrings";
 
+const testcases = [
+  {
+    input: {
+      a: "a",
+      b: "b",
+      c: ""
+    },
+    expected: {
+      a: "a",
+      b: "b"
+    }
+  }
+];
 describe("removeEmptyStrings", () => {
-  it("should remove attributes with empty strings from an object", () => {
-    const testcases = [
-      {
-        input: {
-          a: "a",
-          b: "b",
-          c: ""
-        },
-        expected: {
-          a: "a",
-          b: "b"
-        }
-      }
-    ];
-
-    testcases.forEach(({ input, expected }) => {
+  testcases.forEach(({ input, expected }) => {
+    it("test", () => {
       expect(removeEmptyStrings(input)).toEqual(expected);
     });
   });


### PR DESCRIPTION
I made all GraphQLList types into GraphQLConnections. I think this has already been done on the frontend by @kadenBeckstead  (correct me if I am wrong).

_edit: For this piece, I think the only change that will need to be made to the frontend would be grabbing `{ edges: [] }` instead of just `[ ]`. If this has already been done, then ignore this..._

Also, I finished up @Bobleyl 's filtering method, applied it to all of our scan operations, and tested it. We should now have filtering on pretty much everything now. Woohoo!

Here are a few examples of how filtering will work:

with the offers table:
```
query {
  store {
    offers(filters:[{field:"wage_type", value:"Hourly", comp:"="}]) {
      edges {
        id
        student_id
        position_type
        position_title
        benefits_description
      }
    }
  }
}
```

with the "GetMajors" query (this one is a little weird because it filters based on the student table):
```
query {
  store {
    majors(filters:[{field:"academic_year", value:"Senior", comp:"="}])
  }
}
```


Finally, I fixed a few little bugs in the test suite.