### PR TITLE
Add support for non-string filter types

### DIFF
--- a/src/graphql/resolvers/resolverHelper.js
+++ b/src/graphql/resolvers/resolverHelper.js
@@ -67,7 +67,6 @@ const dbScan = async (db, table, filters) => {
     ExpressionAttributeNames = {};
     FilterExpression = "";
     for (let i in preFilters) {
-      console.log(preFilters[i]);
       const { field, value, comp, parseValueAs } = preFilters[i];
       const fieldName = `#${field}`;
       FilterExpression += `${fieldName} ${comp} :${field}`;
@@ -85,8 +84,6 @@ const dbScan = async (db, table, filters) => {
     ExpressionAttributeValues,
     ExpressionAttributeNames
   };
-
-  console.log(params);
 
   let results = await db.scan(params).promise();
   let items = results.Items || [];

--- a/src/graphql/resolvers/resolverHelper.js
+++ b/src/graphql/resolvers/resolverHelper.js
@@ -63,7 +63,7 @@ const dbScan = async (db, table, filters) => {
     }
   }
 
-  let params = {
+  const params = {
     TableName: table,
     FilterExpression,
     ExpressionAttributeValues,
@@ -73,10 +73,8 @@ const dbScan = async (db, table, filters) => {
   let results = await db.scan(params).promise();
   let items = results.Items || [];
   if (Array.isArray(items)) {
-    //Array of items
     return items.filter(i => passesFilters(postFilters, i));
   } else {
-    //Single item
     return passesFilters(postFilters, items) ? items : [];
   }
 };

--- a/src/graphql/resolvers/resolverHelper.js
+++ b/src/graphql/resolvers/resolverHelper.js
@@ -36,7 +36,7 @@ const passesFilter = (filter, item) => {
 };
 
 const passesFilters = (filters, item) => {
-  return !filters.some(f => !passesFilter(f, item));
+  return filters == null || !filters.some(f => !passesFilter(f, item));
 };
 
 const dbScan = async (db, table, filters) => {
@@ -71,7 +71,14 @@ const dbScan = async (db, table, filters) => {
   };
 
   let results = await db.scan(params).promise();
-  return results.Items.filter(i => passesFilters(postFilters, i)) || [];
+  let items = results.Items || [];
+  if (Array.isArray(items)) {
+    //Array of items
+    return items.filter(i => passesFilters(postFilters, i));
+  } else {
+    //Single item
+    return passesFilters(postFilters, items) ? items : [];
+  }
 };
 
 export { dbQuery, dbScan };

--- a/src/graphql/resolvers/resolverHelper.js
+++ b/src/graphql/resolvers/resolverHelper.js
@@ -9,28 +9,61 @@ const dbQuery = async (db, table, item_id) => {
   return response.Item || {};
 };
 
+const getDeepAttribute = (item, path) => {
+  let dot;
+  if ((dot = path.indexOf(".")) >= 0) {
+    let attr = path.slice(0, dot);
+    return getDeepAttribute(item[attr], path.slice(dot + 1));
+  } else {
+    return item[path];
+  }
+};
+
+const passesFilter = (filter, item) => {
+  let actual = getDeepAttribute(item, filter.field);
+  switch (filter.comp) {
+    case "=":
+      return actual === filter.value;
+    case ">":
+      return actual > filter.value;
+    case "<":
+      return actual < filter.value;
+    case ">=":
+      return actual >= filter.value;
+    case "<=":
+      return actual <= filter.value;
+  }
+};
+
+const passesFilters = (filters, item) => {
+  return !filters.some(f => !passesFilter(f, item));
+};
+
 const dbScan = async (db, table, filters) => {
   let FilterExpression;
   let ExpressionAttributeValues;
   let ExpressionAttributeNames;
 
-  if (filters) {
+  let preFilters = filters && filters.filter(f => !f.field.includes("."));
+  let postFilters = filters && filters.filter(f => f.field.includes("."));
+
+  if (preFilters && preFilters.length) {
     ExpressionAttributeValues = {};
     ExpressionAttributeNames = {};
     FilterExpression = "";
-    for (let i in filters) {
-      const { field, value, comp } = filters[i];
+    for (let i in preFilters) {
+      const { field, value, comp } = preFilters[i];
       const fieldName = `#${field}`;
       FilterExpression += `${fieldName} ${comp} :${field}`;
       ExpressionAttributeValues[`:${field}`] = value;
       ExpressionAttributeNames[`${fieldName}`] = field;
-      if (i < filters.length - 1) {
+      if (i < preFilters.length - 1) {
         FilterExpression += " AND ";
       }
     }
   }
 
-  const params = {
+  let params = {
     TableName: table,
     FilterExpression,
     ExpressionAttributeValues,
@@ -38,7 +71,7 @@ const dbScan = async (db, table, filters) => {
   };
 
   let results = await db.scan(params).promise();
-  return results.Items || [];
+  return results.Items.filter(i => passesFilters(postFilters, i)) || [];
 };
 
 export { dbQuery, dbScan };

--- a/src/graphql/resolvers/resolverHelper.js
+++ b/src/graphql/resolvers/resolverHelper.js
@@ -48,6 +48,8 @@ const parseAs = (value, type) => {
       return parseInt(value);
     case "float":
       return parseFloat(value);
+    case "boolean":
+      return value === "true";
     default:
       console.error(`Unknown parseType: ${type}`);
       return value;

--- a/src/graphql/resolvers/resolverHelper.js
+++ b/src/graphql/resolvers/resolverHelper.js
@@ -21,22 +21,37 @@ const getDeepAttribute = (item, path) => {
 
 const passesFilter = (filter, item) => {
   let actual = getDeepAttribute(item, filter.field);
+  let filterValue = parseAs(filter.value, filter.parseValueAs);
   switch (filter.comp) {
     case "=":
-      return actual === filter.value;
+      return actual === filterValue;
     case ">":
-      return actual > filter.value;
+      return actual > filterValue;
     case "<":
-      return actual < filter.value;
+      return actual < filterValue;
     case ">=":
-      return actual >= filter.value;
+      return actual >= filterValue;
     case "<=":
-      return actual <= filter.value;
+      return actual <= filterValue;
   }
 };
 
 const passesFilters = (filters, item) => {
   return filters == null || !filters.some(f => !passesFilter(f, item));
+};
+
+const parseAs = (value, type) => {
+  switch (type) {
+    case "string":
+      return `${value}`;
+    case "int":
+      return parseInt(value);
+    case "float":
+      return parseFloat(value);
+    default:
+      console.error(`Unknown parseType: ${type}`);
+      return value;
+  }
 };
 
 const dbScan = async (db, table, filters) => {
@@ -52,10 +67,11 @@ const dbScan = async (db, table, filters) => {
     ExpressionAttributeNames = {};
     FilterExpression = "";
     for (let i in preFilters) {
-      const { field, value, comp } = preFilters[i];
+      console.log(preFilters[i]);
+      const { field, value, comp, parseValueAs } = preFilters[i];
       const fieldName = `#${field}`;
       FilterExpression += `${fieldName} ${comp} :${field}`;
-      ExpressionAttributeValues[`:${field}`] = value;
+      ExpressionAttributeValues[`:${field}`] = parseAs(value, parseValueAs);
       ExpressionAttributeNames[`${fieldName}`] = field;
       if (i < preFilters.length - 1) {
         FilterExpression += " AND ";
@@ -69,6 +85,8 @@ const dbScan = async (db, table, filters) => {
     ExpressionAttributeValues,
     ExpressionAttributeNames
   };
+
+  console.log(params);
 
   let results = await db.scan(params).promise();
   let items = results.Items || [];

--- a/src/graphql/types/filterType.js
+++ b/src/graphql/types/filterType.js
@@ -3,7 +3,8 @@ import { GraphQLString, GraphQLList, GraphQLInputObjectType } from "graphql";
 const filter = {
   field: { type: GraphQLString },
   value: { type: GraphQLString },
-  comp: { type: GraphQLString }
+  comp: { type: GraphQLString },
+  parseValueAs: { type: GraphQLString }
 };
 
 const FilterType = new GraphQLInputObjectType({


### PR DESCRIPTION
Adds a `parseValueAs` field to the Filter type in the schema, which allows non-string values to be used as filter values.